### PR TITLE
Demonstration of a unified Onramp

### DIFF
--- a/packages/omgx/wallet/wallet/src/containers/account/Account.js
+++ b/packages/omgx/wallet/wallet/src/containers/account/Account.js
@@ -207,7 +207,7 @@ function Account () {
               disabled={!isSynced || criticalTransactionLoading}
               style={{maxWidth: '150px', padding: '8px'}}
             >
-              FAST ONRAMP<ArrowForward/>
+              ONRAMP<ArrowForward/>
             </Button>
           </div>
         }
@@ -220,18 +220,6 @@ function Account () {
               style={{maxWidth: '150px', padding: '8px'}}
             > 
             <ArrowBack/>FAST EXIT
-            </Button>
-          </div>
-        }
-        {networkLayer === 'L1' &&
-          <div className={styles.buttons}>
-            <Button
-              onClick={() => handleModalClick('depositModal')}
-              type='primary'
-              disabled={!isSynced || criticalTransactionLoading}
-              style={{maxWidth: '150px', padding: '8px'}}
-            >
-              SLOW ONRAMP<ArrowForward/>
             </Button>
           </div>
         }

--- a/packages/omgx/wallet/wallet/src/containers/modals/deposit/steps/InputStep.js
+++ b/packages/omgx/wallet/wallet/src/containers/modals/deposit/steps/InputStep.js
@@ -44,9 +44,11 @@ function InputStep ({
   async function depositETH () {
     if (value > 0 && tokenInfo) {
       let res
-      if (fast) {
+      if (Number(value) < (Number(LPBalance) / 2)) {
+        dispatch(openAlert(`About to transfer ${(Number(value) * 1.00).toFixed(2)} into oETH on L2 using Fast channel`));
         res = await dispatch(depositL1LP(currency, value))
       } else {
+        dispatch(openAlert(`About to transfer ${(Number(value) * 1.00).toFixed(2)} into oETH on L2 using Slow channel`));
         res = await dispatch(depositETHL2(value));
       }
       if (res) {
@@ -63,7 +65,7 @@ function InputStep ({
     }
   }
 
-  const disabledSubmit = value <= 0 || !currency || !ethers.utils.isAddress(currency) || (fast && Number(value) > Number(LPBalance));
+  const disabledSubmit = value <= 0 || !currency || !ethers.utils.isAddress(currency);
 
   if (fast && Object.keys(tokenInfo).length && currency) {
     networkService.L2LPBalance(currency).then((LPBalance)=>{
@@ -77,13 +79,7 @@ function InputStep ({
   return (
     <>
 
-      {fast &&
-        <h2>Fast swap onto OMGX</h2>
-      }
-
-      {!fast &&
-        <h2>Traditional Deposit</h2>
-      }
+      <h2>Unified onramp onto OMGX</h2>
       
       <Tabs
         className={styles.tabs}
@@ -114,11 +110,10 @@ function InputStep ({
         onChange={i=>setValue(i.target.value)} 
       />
 
-      {fast && activeTab1 === 'ETH' && Object.keys(tokenInfo).length && currency ? (
+      {activeTab1 === 'ETH' && Object.keys(tokenInfo).length && currency ? (
         <>
           <h3>
-            The L2 liquidity pool has {LPBalance} oETH. The liquidity fee is {feeRate}%.{" "} 
-            {value && `You will receive ${(Number(value) * 0.97).toFixed(2)} oETH on L2.`}
+            The L2 liquidity pool has {LPBalance} oETH. Onramp requests of {(Number(LPBalance) / 2.0).toFixed(2)} or less will be processed through the pool.
           </h3>
         </>
       ):<></>}


### PR DESCRIPTION
With this change the user sees a single Onramp button and the wallet code decides whether to process it using the Fast or Slow mechanisms. In this example, any request for less than 1/2 of the present oETH balance on the L2 side will be processed as a Fast swap. Larger requests will be sent through the direct (Slow) path. Other factors could be considered as well, e.g. only using a Fast swap if the L2 liquidity balance was greater than on the L1 side.

Instead of making the decision here, it would also be possible to send all of the L1->L2 requests to a smart contract and have that contract make the decision about which channel to use. This would have a higher L1 gas cost, but there might be advantages e.g. avoiding race conditions where multiple users generate Fast swap requests at the same time and thereby exhaust the L2 oETH balance.

This patch does not do anything regarding fees. In the real world the fee paid by the user should be the same regardless of which path our code chooses. The fee for L1->L2 swaps should probably be 0, with a user only paying for using the pool in the L2->L1 exit direction. However an L1->L2 fee might also be acceptable to users if we can provide a convincing explanation for why it's there.

Changes to be committed:
	modified:   packages/omgx/wallet/wallet/src/containers/account/Account.js
	modified:   packages/omgx/wallet/wallet/src/containers/modals/deposit/steps/InputStep.js