### PR TITLE
experiment w/ atomic/thread-safe approach to passing Geth L1 timestamps an…

### DIFF
--- a/l2geth/eth/api_backend.go
+++ b/l2geth/eth/api_backend.go
@@ -66,9 +66,10 @@ func (b *EthAPIBackend) GasLimit() uint64 {
 }
 
 func (b *EthAPIBackend) GetEthContext() (uint64, uint64) {
-	bn := b.eth.syncService.GetLatestL1BlockNumber()
-	ts := b.eth.syncService.GetLatestL1Timestamp()
-	return bn, ts
+    ts, bn := b.eth.syncService.GetLatestL1SafeTimeBlock()
+	//bn := b.eth.syncService.GetLatestL1BlockNumber()
+	//ts := b.eth.syncService.GetLatestL1Timestamp()
+	return bn, ts //note flipped order - do not unflip, as tempting as it may be
 }
 
 func (b *EthAPIBackend) GetRollupContext() (uint64, uint64, uint64) {
@@ -126,9 +127,32 @@ func (b *EthAPIBackend) SetHead(number uint64) {
 		return
 	}
 
-	b.eth.syncService.SetLatestL1Timestamp(tx.L1Timestamp())
-	b.eth.syncService.SetLatestL1BlockNumber(blockNumber.Uint64())
+	//b.eth.syncService.SetLatestL1Timestamp(tx.L1Timestamp())
+	//b.eth.syncService.SetLatestL1BlockNumber(blockNumber.Uint64())
+	b.eth.syncService.SetLatestL1SafeTimeBlock(tx.L1Timestamp(),blockNumber.Uint64())
 }
+
+
+/*
+func (b *EthAPIBackend) GetEthContext() (uint64, uint64) {
+
+/*
+//GetLatestL1Timestamp returns the OVMContext timestamp
+func (s *SyncService) GetLatestL1SafeTimeBlock() tOVMContext {
+	return s.safeTimeBlock.Load().(tOVMContext)
+}
+
+//SetLatestL1Timestamp will set the OVMContext timestamp
+func (s *SyncService) SetLatestL1SafeTimeBlock(stb tOVMContext) {
+	s.safeTimeBlock.Store(stb)
+}
+*/
+//    stb := b.eth.syncService.GetLatestL1SafeTimeBlock()
+	//bn := b.eth.syncService.GetLatestL1BlockNumber()
+	//ts := b.eth.syncService.GetLatestL1Timestamp()
+//	return stb.blockNumber, stb.timestamp
+	//return bn, ts
+//}
 
 func (b *EthAPIBackend) IngestTransactions(txs []*types.Transaction) error {
 	for _, tx := range txs {

--- a/l2geth/rollup/sync_service_test.go
+++ b/l2geth/rollup/sync_service_test.go
@@ -249,7 +249,11 @@ func TestTransactionToTipTimestamps(t *testing.T) {
 			t.Fatalf("Mismatched index: got %d, expect %d", *conf.GetMeta().Index, nextIndex)
 		}
 		// The tx timestamp should be setting the services timestamp
-		if conf.L1Timestamp() != service.GetLatestL1Timestamp() {
+		// if conf.L1Timestamp() != service.GetLatestL1Timestamp() {
+		// 	t.Fatal("Mismatched timestamp")
+		// }
+		ts, _ := service.GetLatestL1SafeTimeBlock()
+		if conf.L1Timestamp() != ts {
 			t.Fatal("Mismatched timestamp")
 		}
 	}
@@ -257,7 +261,8 @@ func TestTransactionToTipTimestamps(t *testing.T) {
 	// Send a transaction with no timestamp and then let it be updated
 	// by the sync service. This will prevent monotonicity errors as well
 	// as give timestamps to queue origin sequencer transactions
-	ts := service.GetLatestL1Timestamp()
+	//ts := service.GetLatestL1Timestamp()
+	ts, _ := service.GetLatestL1SafeTimeBlock()
 	tx3 := setMockTxL1Timestamp(mockTx(), 0)
 	go func() {
 		err = service.applyTransactionToTip(tx3)
@@ -654,8 +659,10 @@ func TestInitializeL1ContextPostGenesis(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	latestL1Timestamp := service.GetLatestL1Timestamp()
-	latestL1BlockNumber := service.GetLatestL1BlockNumber()
+	//latestL1Timestamp := service.GetLatestL1Timestamp()
+	//latestL1BlockNumber := service.GetLatestL1BlockNumber()
+	latestL1Timestamp, latestL1BlockNumber := service.GetLatestL1SafeTimeBlock()
+
 	if number != latestL1BlockNumber {
 		t.Fatalf("number does not match, got %d, expected %d", latestL1BlockNumber, number)
 	}

--- a/l2geth/rollup/types.go
+++ b/l2geth/rollup/types.go
@@ -15,6 +15,14 @@ type OVMContext struct {
 	timestamp   uint64
 }
 
+// OVMContext represents the blocknumber and timestamp
+// that exist during L2 execution
+// for testing
+type OVMContextT struct {
+	blockNumber uint64
+	timestamp   uint64
+}
+
 // Backend represents the type of transactions that are being synced.
 // The different types have different security models.
 type Backend uint


### PR DESCRIPTION
When accessing `blockNumbers` and `timestamps` in memory, might be safer access them via _one_ function and store them as an `atomic.Value{}`. The worry is that by having separate setters and getters, there might be situations in which a process changes the timestamp after the blockNumber is returned, leading to a corrupted {timestamp,blockNumber} pair being passed to later functions and data structures. 

*Experimental approach*:
```
safeTimeBlock: atomic.Value{},

// Log the OVMContext information on startup
stb := service.safeTimeBlock.Load().(OVMContextT)
log.Info("Initialized Latest L1 Info Safe", "stb.timestamp", stb.timestamp, "stb.blocknumber", stb.blockNumber)
```
*Current approach code snippets*:
```
func (s *SyncService) GetLatestL1BlockNumber() uint64 {
    return atomic.LoadUint64(&s.OVMContext.blockNumber)
}
...
ts := s.GetLatestL1Timestamp()
bn := s.GetLatestL1BlockNumber()
```