### PR TITLE
Mm/geth dtl fixes jul25

### DIFF
--- a/.github/workflows/omgx-integration.yml
+++ b/.github/workflows/omgx-integration.yml
@@ -23,7 +23,8 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          #aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: us-east-1
       - name: Start EC2 runner
         id: start-ec2-runner
         uses: machulav/ec2-github-runner@v2
@@ -161,7 +162,8 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          #aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: us-east-1
       - name: Stop EC2 runner
         uses: machulav/ec2-github-runner@v2
         with:

--- a/l2geth/miner/worker.go
+++ b/l2geth/miner/worker.go
@@ -473,7 +473,7 @@ func (w *worker) mainLoop() {
 				}
 				txn := txs[0]
 				height := head.Block.Number().Uint64()
-				log.Debug("Miner got new head", "height", height, "block-hash", head.Block.Hash().Hex(), "tx-hash", txn.Hash().Hex(), "tx-hash", tx.Hash().Hex())
+				log.Debug("Miner got new head", "height", height, "block-hash", head.Block.Hash().Hex(), "txn-hash", txn.Hash().Hex(), "tx-hash", tx.Hash().Hex())
 			} else {
 				log.Debug("Problem committing transaction: %w", err)
 			}

--- a/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
@@ -261,7 +261,7 @@ const maybeDecodeSequencerBatchTransaction = (
       gasPrice: BigNumber.from(decodedTx.gasPrice).toString(),
       gasLimit: BigNumber.from(decodedTx.gasLimit).toString(),
       value: toRpcHexString(decodedTx.value),
-      target: toHexString(decodedTx.to), // Maybe null this out for creations?
+      target: decodedTx.to ? toHexString(decodedTx.to):null, // Maybe null this out for creations?
       data: toHexString(decodedTx.data),
       sig: {
         v: parseSignatureVParam(decodedTx.v, l2ChainId),

--- a/packages/data-transport-layer/src/types/api-types.ts
+++ b/packages/data-transport-layer/src/types/api-types.ts
@@ -10,6 +10,14 @@ export type EnqueueResponse = EnqueueEntry & {
   ctcIndex: number | null
 }
 
+export interface EnqueueInfoResponse {
+  index: number | null
+  blockNumber: number
+  timestamp: number
+  baseBlock: number
+  baseTime: number
+}
+
 export interface TransactionResponse {
   batch: TransactionBatchEntry
   transaction: TransactionEntry


### PR DESCRIPTION
I've re-structured some of the interactions between l2geth and the data-translation-layer to fix one source of the timestamp monotonicity violations which showed up when running the integration stress tests against my local system. 
This Jul25 branch is rebased onto the current 'develop' and includes fixes for 2 additional issues I found since submitting the previous PR. Please try it out and see if it works in other environments.