### PR TITLE
enable   COMPOSE_DOCKER_CLI_BUILD in .github/workflows/omgx-integration.yml

### DIFF
--- a/.github/workflows/omgx-integration.yml
+++ b/.github/workflows/omgx-integration.yml
@@ -40,8 +40,8 @@ jobs:
     needs: start-runner
     runs-on: ${{ needs.start-runner.outputs.label }}
     env:
-      #DOCKER_BUILDKIT: 1
-      #COMPOSE_DOCKER_CLI_BUILD: 1
+      DOCKER_BUILDKIT: 1
+      COMPOSE_DOCKER_CLI_BUILD: 1
       TEST_PRIVATE_KEY_1: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
       TEST_PRIVATE_KEY_2: "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba"
       TEST_PRIVATE_KEY_3: "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e"

--- a/.github/workflows/push2aws.yml
+++ b/.github/workflows/push2aws.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - develop
-      - 'memory_and_omg-monitor'
 
 jobs:
   push2aws:


### PR DESCRIPTION
OMGX Services do require BUILD enabled, to actually start the integration tests.
WHY: https://github.com/omgnetwork/optimism/runs/3220203277 