### PR TITLE
Fix receipt of null

### DIFF
--- a/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
@@ -244,11 +244,12 @@ export abstract class BatchSubmitter {
     }
 
     this.logger.info('Received transaction receipt', { receipt })
-    this.logger.info(successMessage, {
-      block:receipt.blockNumber,
-      status:receipt.status,
-      txHash:receipt.transactionHash,
-    })
+    // this.logger.info(successMessage, {
+    //   block:receipt.blockNumber,
+    //   status:receipt.status,
+    //   txHash:receipt.transactionHash,
+    // })
+    this.logger.info(successMessage)
     this.metrics.batchesSubmitted.inc()
     this.metrics.submissionGasUsed.observe(
       receipt ? receipt.gasUsed.toNumber() : 0


### PR DESCRIPTION
* The receipt is null, so the batch submitter retries to submit it again.
* Error code:
```
{"level":50,"time":1631566362785,"extra":{"message":"TypeError: Cannot read property 'blockNumber' of null","stack":"TypeError: Cannot read property 'blockNumber' of null\n    at TransactionBatchSubmitter._submitAndLogTx (/Users/chenboyuan/Documents/GitHub/optimism.nosync/packages/batch-submitter/src/batch-submitter/batch-submitter.ts:250:21)\n    at loop (/Users/chenboyuan/Documents/GitHub/optimism.nosync/packages/batch-submitter/src/exec/run-batch-submitter.ts:467:9)"},"msg":"Unhandled exception during batch submission"}
{"level":30,"time":1631566362785,"msg":"Retrying..."}
```