### PR TITLE
Add log and data storage for L2 revenue

### DIFF
--- a/packages/omgx/gas-price-oracle/src/service.ts
+++ b/packages/omgx/gas-price-oracle/src/service.ts
@@ -142,6 +142,7 @@ export class GasPriceOracleService extends BaseService<GasPriceOracleOptions> {
   private async _loadL2ETHCost(): Promise<void> {
     const vaultBalance =
       BigNumber.from((await this.state.OVM_oETH.balanceOf(this.options.OVM_SequencerFeeVault)).toString())
+    // load data
     const dumpsPath = path.resolve(__dirname, '../data/l2History.json')
     if (fs.existsSync(dumpsPath)) {
       this.logger.warn('Loading L2 cost history...')
@@ -155,7 +156,11 @@ export class GasPriceOracleService extends BaseService<GasPriceOracleOptions> {
       }
     } else {
       this.logger.warn('No L2 cost history Found!')
-      this.state.L2ETHCollectFee = vaultBalance;
+      this.state.L2ETHCollectFee = vaultBalance
+    }
+    // adjust the L2ETHCollectFee if it is not correct
+    if (this.state.L2ETHCollectFee.lt(vaultBalance)) {
+      this.state.L2ETHCollectFee = vaultBalance
     }
     this.state.L2ETHVaultBalance = vaultBalance
     this.logger.info('Loaded L2 Cost Data', {


### PR DESCRIPTION
* Add 10X data log
* Add the data storage for L2 revenue, so it can correctly record the l2 fee after the oETH is withdrawn from the vault