### PR TITLE
Fix the decimal place of the balance data in the gas oracle's log

### DIFF
--- a/packages/omgx/gas-price-oracle/src/service.ts
+++ b/packages/omgx/gas-price-oracle/src/service.ts
@@ -230,14 +230,14 @@ export class GasPriceOracleService extends BaseService<GasPriceOracleOptions> {
     this.state.lastQueriedL1Block = await this.options.l2RpcProvider.getBlockNumber()
 
     // write history
-    this._writeL1ETHFee();
+    this._writeL1ETHFee()
 
     this.logger.info("Got L1 ETH balances", {
       network: "L1",
       data: {
         L1ETHBalance: this.state.L1ETHBalance.toString(),
-        L1ETHCostFee: Number(utils.formatEther(this.state.L1ETHCostFee.toString()).slice(0, 8)),
-        L1ETHCostFee10X: Number(utils.formatEther(this.state.L1ETHCostFee.toString()).slice(0, 8)) * 10,
+        L1ETHCostFee: Number(utils.formatEther(this.state.L1ETHCostFee.toString())).toFixed(6),
+        L1ETHCostFee10X: (Number(utils.formatEther(this.state.L1ETHCostFee.toString())) * 10).toFixed(6),
         latestQueriedL1Block: this.state.lastQueriedL1Block,
       }
     })
@@ -282,8 +282,8 @@ export class GasPriceOracleService extends BaseService<GasPriceOracleOptions> {
     this.logger.info("Got L2 Gas Cost", {
       network: "L2",
       data: {
-        L2ETHCollectFee: Number(utils.formatEther(this.state.L2ETHCollectFee.toString()).slice(0, 8)),
-        L2ETHCollectFee10X: Number(utils.formatEther(this.state.L2ETHCollectFee.toString()).slice(0, 8)) * 10,
+        L2ETHCollectFee: Number(utils.formatEther(this.state.L2ETHCollectFee.toString())).toFixed(6),
+        L2ETHCollectFee10X: (Number(utils.formatEther(this.state.L2ETHCollectFee.toString())) * 10).toFixed(6),
         lastQueriedL2Block: this.state.lastQueriedL2Block,
         avgL2GasUsagePerBlock: this.state.avgL2GasLimitPerBlock.toString(),
         numberOfBlocksInterval: this.state.numberOfBlocksInterval,

--- a/packages/omgx/gas-price-oracle/src/service.ts
+++ b/packages/omgx/gas-price-oracle/src/service.ts
@@ -142,6 +142,7 @@ export class GasPriceOracleService extends BaseService<GasPriceOracleOptions> {
   private async _loadL2ETHCost(): Promise<void> {
     const vaultBalance =
       BigNumber.from((await this.state.OVM_oETH.balanceOf(this.options.OVM_SequencerFeeVault)).toString())
+    // load data
     const dumpsPath = path.resolve(__dirname, '../data/l2History.json')
     if (fs.existsSync(dumpsPath)) {
       this.logger.warn('Loading L2 cost history...')
@@ -155,7 +156,11 @@ export class GasPriceOracleService extends BaseService<GasPriceOracleOptions> {
       }
     } else {
       this.logger.warn('No L2 cost history Found!')
-      this.state.L2ETHCollectFee = vaultBalance;
+      this.state.L2ETHCollectFee = vaultBalance
+    }
+    // adjust the L2ETHCollectFee if it is not correct
+    if (this.state.L2ETHCollectFee.lt(vaultBalance)) {
+      this.state.L2ETHCollectFee = vaultBalance
     }
     this.state.L2ETHVaultBalance = vaultBalance
     this.logger.info('Loaded L2 Cost Data', {


### PR DESCRIPTION
The double type in the the datadog has restrictions on the decimal place and data type. The numbers in logs have 6 decimal places, so it can be indexed in the datadog.