### PR TITLE
Improve the way to query fast exit data

### DIFF
--- a/ops_omgx/monitor/transaction-monitor/services/database.service.js
+++ b/ops_omgx/monitor/transaction-monitor/services/database.service.js
@@ -237,7 +237,7 @@ class DatabaseService extends OptimismEnv{
     const crossDomainMessage = await query(`SELECT * FROM receipt
       WHERE crossDomainMessage=${true}
       AND crossDomainMessageFinalize=${false}
-      AND UNIX_TIMESTAMP() > crossDomainMessageEstimateFinalizedTime
+      AND ((UNIX_TIMESTAMP() > crossDomainMessageEstimateFinalizedTime AND fastRelay is null) OR fastRelay=true)
     `);
     con.end();
     return crossDomainMessage;
@@ -257,7 +257,6 @@ class DatabaseService extends OptimismEnv{
       on depositL2.hash = l1Bridge.hash
       WHERE crossDomainMessage=${true}
       AND depositL2.status='pending'
-      AND UNIX_TIMESTAMP() > crossDomainMessageEstimateFinalizedTime
     `);
     con.end();
     return crossDomainMessage;


### PR DESCRIPTION
The transaction monitor checks the status of fast cdm when it finds it regardless of the estimated finalized time. It increases the API call, but it can provide a better user experience. closed #503 