### PR TITLE
Fix message relayers and check gas price

### DIFF
--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -80,7 +80,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     )
     this.disableQueueBatchAppend = disableQueueBatchAppend
     this.autoFixBatchOptions = autoFixBatchOptions
-    this.gasThresholdInGwei = 500
+    this.gasThresholdInGwei = gasThresholdInGwei
     this.transactionSubmitter = transactionSubmitter
   }
 

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L1CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L1CrossDomainMessenger.sol
@@ -70,6 +70,7 @@ contract OVM_L1CrossDomainMessenger is
     mapping (bytes32 => bool) public blockedMessages;
     mapping (bytes32 => bool) public relayedMessages;
     mapping (bytes32 => bool) public successfulMessages;
+    mapping (bytes32 => bool) public failedMessages;
 
     address internal xDomainMsgSender = DEFAULT_XDOMAIN_SENDER;
 
@@ -278,6 +279,7 @@ contract OVM_L1CrossDomainMessenger is
             successfulMessages[xDomainCalldataHash] = true;
             emit RelayedMessage(xDomainCalldataHash);
         } else {
+            failedMessages[xDomainCalldataHash] = true;
             emit FailedRelayedMessage(xDomainCalldataHash);
         }
 

--- a/packages/message-relayer/src/exec/run.ts
+++ b/packages/message-relayer/src/exec/run.ts
@@ -79,10 +79,8 @@ const main = async () => {
     'from-l2-transaction-index',
     parseInt(env.FROM_L2_TRANSACTION_INDEX, 10) || 0
   )
-  const FILTER_ENDPOINT = config.str(
-    'filter-endpoint',
-    env.FILTER_ENDPOINT
-  ) || ''
+  const FILTER_ENDPOINT =
+    config.str('filter-endpoint', env.FILTER_ENDPOINT) || ''
   const FILTER_POLLING_INTERVAL = config.uint(
     'filter-polling-interval',
     parseInt(env.FILTER_POLLING_INTERVAL, 10) || 60000
@@ -101,7 +99,7 @@ const main = async () => {
   )
   const NUM_CONFIRMATIONS = config.uint(
     'num-confirmations',
-    parseInt(env.NUM_CONFIRMATIONS, 10) ||  0
+    parseInt(env.NUM_CONFIRMATIONS, 10) || 0
   )
 
   if (!ADDRESS_MANAGER_ADDRESS) {

--- a/packages/message-relayer/src/service.ts
+++ b/packages/message-relayer/src/service.ts
@@ -103,7 +103,7 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
     timeSinceLastRelayS: number
     timeOfLastRelayS: number
     messageBuffer: Array<BatchMessage>
-  timeOfLastPendingRelay: any
+    timeOfLastPendingRelay: any
   }
 
   protected async _init(): Promise<void> {
@@ -242,33 +242,50 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
           this.state.messageBuffer.length >= this.options.minBatchSize
             ? true : false
 
+        // check gas price
+        const gasPrice = await this.options.l1RpcProvider.getGasPrice()
+        const gasPriceGwei = Number(ethers.utils.formatUnits(gasPrice, 'gwei'))
+        const gasPriceAcceptable =
+          gasPriceGwei < this.options.maxGasPriceInGwei ? true : false
+
         if (this.state.messageBuffer.length !== 0 && (bufferFull || timeOut) && pendingTXTimeOut) {
-          if (bufferFull) {
-            console.log('Buffer full: flushing')
-          }
-          if (timeOut) {
-            console.log('Buffer timeout: flushing')
-          }
+          if (gasPriceAcceptable) {
+            if (bufferFull) {
+              console.log('Buffer full: flushing')
+            }
+            if (timeOut) {
+              console.log('Buffer timeout: flushing')
+            }
 
-          const receipt = await this._relayMultiMessageToL1(
-            this.state.messageBuffer.reduce((acc, cur) => {
-              acc.push(cur.payload)
-              return acc
-            }, [])
-          )
+            const receipt = await this._relayMultiMessageToL1(
+              this.state.messageBuffer.reduce((acc, cur) => {
+                acc.push(cur.payload)
+                return acc
+              }, [])
+            )
 
-          console.log('Receipt:', receipt)
+            console.log('Receipt:', receipt)
 
-          /* parse this to make sure that the mesaage was actually relayed */
-          // clear out buffer only if the messages are relayed to L1 successfully
-          if (
-            await this._wasMessageRelayed(this.state.messageBuffer[0].message)
-          ) {
-            //clear out the buffer so we do not double relay, which will just
-            // waste gas
-            this.state.messageBuffer = []
-            this.state.timeOfLastPendingRelay = false
+            /* parse this to make sure that the mesaage was actually relayed */
+            // clear out buffer only if the messages are relayed to L1 successfully
+            if (
+              await this._wereMessagesRelayed(
+                this.state.messageBuffer.reduce((acc, cur) => {
+                  acc.push(cur.message)
+                  return acc
+                }, [])
+              )
+            ) {
+              //clear out the buffer so we do not double relay, which will just
+              // waste gas
+              this.state.messageBuffer = []
+              this.state.timeOfLastPendingRelay = false
+            } else {
+              // add the time interval between two tx
+              this.state.timeOfLastPendingRelay = Date.now()
+            }
           } else {
+            console.log('Current gas price is unacceptable')
             // add the time interval between two tx
             this.state.timeOfLastPendingRelay = Date.now()
           }
@@ -341,6 +358,16 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
             })
             if (await this._wasMessageRelayed(message)) {
               this.logger.info('Message has already been relayed, skipping.')
+              continue
+            }
+
+            if (await this._wasMessageBlocked(message)) {
+              this.logger.info('Message has been blocked, skipping.')
+              continue
+            }
+
+            if (await this._wasMessageFailed(message)) {
+              this.logger.info('Last message was failed, skipping.')
               continue
             }
 
@@ -577,6 +604,29 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
     return this.state.OVM_L1CrossDomainMessenger.successfulMessages(
       message.encodedMessageHash
     )
+  }
+
+  private async _wasMessageBlocked(message: SentMessage): Promise<boolean> {
+    return this.state.OVM_L1CrossDomainMessenger.blockedMessages(
+      message.encodedMessageHash
+    )
+  }
+
+  private async _wasMessageFailed(message: SentMessage): Promise<boolean> {
+    return this.state.OVM_L1CrossDomainMessenger.failedMessages(
+      message.encodedMessageHash
+    )
+  }
+
+  private async _wereMessagesRelayed(
+    messages: Array<SentMessage>
+  ): Promise<boolean> {
+    const promisePayload = messages.reduce((acc, cur) => {
+      acc.push(this._wasMessageRelayed(cur), this._wasMessageFailed(cur))
+      return acc
+    }, [])
+    const messageRelayedStatus = await Promise.all(promisePayload)
+    return messageRelayedStatus.some((ele) => ele)
   }
 
   private async _getMessageProof(

--- a/packages/message-relayer/src/types.ts
+++ b/packages/message-relayer/src/types.ts
@@ -32,10 +32,15 @@ export interface StateRootProof {
   siblings: string[]
 }
 
-export interface BatchMessage {
+interface BatchMessagePayload {
   target: string
   message: string
   sender: string
   messageNonce: number
   proof: SentMessageProof
+}
+
+export interface BatchMessage {
+  payload: BatchMessagePayload
+  message: SentMessage
 }

--- a/packages/omgx/contracts/contracts/OVM_L1CrossDomainMessengerFast.sol
+++ b/packages/omgx/contracts/contracts/OVM_L1CrossDomainMessengerFast.sol
@@ -30,6 +30,17 @@ import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/
  */
 contract OVM_L1CrossDomainMessengerFast is iOVM_L1CrossDomainMessenger, Lib_AddressResolver, OwnableUpgradeable, PausableUpgradeable, ReentrancyGuardUpgradeable {
 
+    /**********
+     * Events *
+     **********/
+
+    event MessageBlocked(
+        bytes32 indexed _xDomainCalldataHash
+    );
+
+    event MessageAllowed(
+        bytes32 indexed _xDomainCalldataHash
+    );
 
     /*************
      * Constants *
@@ -47,6 +58,7 @@ contract OVM_L1CrossDomainMessengerFast is iOVM_L1CrossDomainMessenger, Lib_Addr
     mapping (bytes32 => bool) public blockedMessages;
     mapping (bytes32 => bool) public relayedMessages;
     mapping (bytes32 => bool) public successfulMessages;
+    mapping (bytes32 => bool) public failedMessages;
 
     address internal xDomainMsgSender = DEFAULT_XDOMAIN_SENDER;
 
@@ -116,6 +128,34 @@ contract OVM_L1CrossDomainMessengerFast is iOVM_L1CrossDomainMessenger, Lib_Addr
     }
 
     /**
+     * Block a message.
+     * @param _xDomainCalldataHash Hash of the message to block.
+     */
+    function blockMessage(
+        bytes32 _xDomainCalldataHash
+    )
+        external
+        onlyOwner
+    {
+        blockedMessages[_xDomainCalldataHash] = true;
+        emit MessageBlocked(_xDomainCalldataHash);
+    }
+
+    /**
+     * Allow a message.
+     * @param _xDomainCalldataHash Hash of the message to block.
+     */
+    function allowMessage(
+        bytes32 _xDomainCalldataHash
+    )
+        external
+        onlyOwner
+    {
+        blockedMessages[_xDomainCalldataHash] = false;
+        emit MessageAllowed(_xDomainCalldataHash);
+    }
+
+    /**
      * Sends a cross domain message to the target messenger.
      * @param _target Target contract address.
      * @param _message Message to send to the target.
@@ -175,6 +215,11 @@ contract OVM_L1CrossDomainMessengerFast is iOVM_L1CrossDomainMessenger, Lib_Addr
             "Provided message has already been received."
         );
 
+        require(
+            blockedMessages[xDomainCalldataHash] == false,
+            "Provided message has been blocked."
+        );
+
         xDomainMsgSender = _sender;
         (bool success, ) = _target.call(_message);
         xDomainMsgSender = DEFAULT_XDOMAIN_SENDER;
@@ -184,6 +229,9 @@ contract OVM_L1CrossDomainMessengerFast is iOVM_L1CrossDomainMessenger, Lib_Addr
         if (success == true) {
             successfulMessages[xDomainCalldataHash] = true;
             emit RelayedMessage(xDomainCalldataHash);
+        } else {
+            failedMessages[xDomainCalldataHash] == true;
+            emit FailedRelayedMessage(xDomainCalldataHash);
         }
 
         // Store an identifier that can be used to prove that the given message was relayed by some

--- a/packages/omgx/message-relayer-fast/src/exec/run.ts
+++ b/packages/omgx/message-relayer-fast/src/exec/run.ts
@@ -57,10 +57,8 @@ const main = async () => {
     'from-l2-transaction-index',
     parseInt(env.FROM_L2_TRANSACTION_INDEX, 10) || 0
   )
-  const FILTER_ENDPOINT = config.str(
-    'filter-endpoint',
-    env.FILTER_ENDPOINT
-  ) || ''
+  const FILTER_ENDPOINT =
+    config.str('filter-endpoint', env.FILTER_ENDPOINT) || ''
   const FILTER_POLLING_INTERVAL = config.uint(
     'filter-polling-interval',
     parseInt(env.FILTER_POLLING_INTERVAL, 10) || 60000
@@ -79,7 +77,7 @@ const main = async () => {
   )
   const NUM_CONFIRMATIONS = config.uint(
     'num-confirmations',
-    parseInt(env.NUM_CONFIRMATIONS, 10) ||  0
+    parseInt(env.NUM_CONFIRMATIONS, 10) || 0
   )
 
   if (!ADDRESS_MANAGER_ADDRESS) {

--- a/packages/omgx/message-relayer-fast/src/service.ts
+++ b/packages/omgx/message-relayer-fast/src/service.ts
@@ -246,33 +246,50 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
           this.state.messageBuffer.length >= this.options.minBatchSize
             ? true : false
 
+        // check gas price
+        const gasPrice = await this.options.l1RpcProvider.getGasPrice()
+        const gasPriceGwei = Number(ethers.utils.formatUnits(gasPrice, 'gwei'))
+        const gasPriceAcceptable =
+          gasPriceGwei < this.options.maxGasPriceInGwei ? true : false
+
         if (this.state.messageBuffer.length !== 0 && (bufferFull || timeOut) && pendingTXTimeOut) {
-          if (bufferFull) {
-            console.log('Buffer full: flushing')
-          }
-          if (timeOut) {
-            console.log('Buffer timeout: flushing')
-          }
+          if (gasPriceAcceptable) {
+            if (bufferFull) {
+              console.log('Buffer full: flushing')
+            }
+            if (timeOut) {
+              console.log('Buffer timeout: flushing')
+            }
 
-          const receipt = await this._relayMultiMessageToL1(
-            this.state.messageBuffer.reduce((acc, cur) => {
-              acc.push(cur.payload)
-              return acc
-            }, [])
-          )
+            const receipt = await this._relayMultiMessageToL1(
+              this.state.messageBuffer.reduce((acc, cur) => {
+                acc.push(cur.payload)
+                return acc
+              }, [])
+            )
 
-          console.log('Receipt:', receipt)
+            console.log('Receipt:', receipt)
 
-          /* parse this to make sure that the mesaage was actually relayed */
-          // clear out buffer only if the messages are relayed to L1 successfully
-          if (
-            await this._wasMessageRelayed(this.state.messageBuffer[0].message)
-          ) {
-            //clear out the buffer so we do not double relay, which will just
-            // waste gas
-            this.state.messageBuffer = []
-            this.state.timeOfLastPendingRelay = false
+            /* parse this to make sure that the mesaage was actually relayed */
+            // clear out buffer only if the messages are relayed to L1 successfully
+            if (
+              await this._wereMessagesRelayed(
+                this.state.messageBuffer.reduce((acc, cur) => {
+                  acc.push(cur.message)
+                  return acc
+                }, [])
+              )
+            ) {
+              //clear out the buffer so we do not double relay, which will just
+              // waste gas
+              this.state.messageBuffer = []
+              this.state.timeOfLastPendingRelay = false
+            } else {
+              // add the time interval between two tx
+              this.state.timeOfLastPendingRelay = Date.now()
+            }
           } else {
+            console.log('Current gas price is unacceptable')
             // add the time interval between two tx
             this.state.timeOfLastPendingRelay = Date.now()
           }
@@ -345,6 +362,16 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
             })
             if (await this._wasMessageRelayed(message)) {
               this.logger.info('Message has already been relayed, skipping.')
+              continue
+            }
+
+            if (await this._wasMessageBlocked(message)) {
+              this.logger.info('Message has been blocked, skipping.')
+              continue
+            }
+
+            if (await this._wasMessageFailed(message)) {
+              this.logger.info('Last message was failed, skipping.')
               continue
             }
 
@@ -569,6 +596,29 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
     return this.state.OVM_L1CrossDomainMessenger.successfulMessages(
       message.encodedMessageHash
     )
+  }
+
+  private async _wasMessageBlocked(message: SentMessage): Promise<boolean> {
+    return this.state.OVM_L1CrossDomainMessenger.blockedMessages(
+      message.encodedMessageHash
+    )
+  }
+
+  private async _wasMessageFailed(message: SentMessage): Promise<boolean> {
+    return this.state.OVM_L1CrossDomainMessenger.failedMessages(
+      message.encodedMessageHash
+    )
+  }
+
+  private async _wereMessagesRelayed(
+    messages: Array<SentMessage>
+  ): Promise<boolean> {
+    const promisePayload = messages.reduce((acc, cur) => {
+      acc.push(this._wasMessageRelayed(cur), this._wasMessageFailed(cur))
+      return acc
+    }, [])
+    const messageRelayedStatus = await Promise.all(promisePayload)
+    return messageRelayedStatus.some((ele) => ele)
   }
 
   private async _getMessageProof(

--- a/packages/omgx/message-relayer-fast/src/service.ts
+++ b/packages/omgx/message-relayer-fast/src/service.ts
@@ -99,6 +99,7 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
     timeSinceLastRelayS: number
     timeOfLastRelayS: number
     messageBuffer: Array<BatchMessage>
+    timeOfLastPendingRelay: any
   }
 
   protected async _init(): Promise<void> {
@@ -194,12 +195,13 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
     this.state.timeOfLastRelayS = Date.now()
     this.state.timeSinceLastRelayS = 0
     this.state.messageBuffer = []
+    this.state.timeOfLastPendingRelay = false
   }
 
   protected async _start(): Promise<void> {
     while (this.running) {
       await sleep(this.options.pollingInterval)
-      await this._getFilter();
+      await this._getFilter()
 
       try {
         // The message is relayed directly, no need to keep cache
@@ -228,12 +230,23 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
         const timeOut =
           secondsElapsed > this.options.maxWaitTimeS ? true : false
 
+        let pendingTXTimeOut = true
+        if (this.state.timeOfLastPendingRelay !== false) {
+          const pendingTXSecondsElapsed = Math.floor(
+            (Date.now() - this.state.timeOfLastPendingRelay) / 1000
+          )
+          console.log('\n***********************************')
+          console.log('Next tx since last tx submitted', pendingTXSecondsElapsed)
+          pendingTXTimeOut =
+            pendingTXSecondsElapsed > this.options.maxWaitTimeS ? true : false
+        }
+
         //console.log('Current buffer size:', this.state.messageBuffer.length)
         const bufferFull =
           this.state.messageBuffer.length >= this.options.minBatchSize
             ? true : false
 
-        if (this.state.messageBuffer.length !== 0 && (bufferFull || timeOut)) {
+        if (this.state.messageBuffer.length !== 0 && (bufferFull || timeOut) && pendingTXTimeOut) {
           if (bufferFull) {
             console.log('Buffer full: flushing')
           }
@@ -242,16 +255,26 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
           }
 
           const receipt = await this._relayMultiMessageToL1(
-            this.state.messageBuffer
+            this.state.messageBuffer.reduce((acc, cur) => {
+              acc.push(cur.payload)
+              return acc
+            }, [])
           )
 
           console.log('Receipt:', receipt)
 
           /* parse this to make sure that the mesaage was actually relayed */
-          if (/*everything went well*/ true) {
+          // clear out buffer only if the messages are relayed to L1 successfully
+          if (
+            await this._wasMessageRelayed(this.state.messageBuffer[0].message)
+          ) {
             //clear out the buffer so we do not double relay, which will just
-            //led to reversion at the SCC level
+            // waste gas
             this.state.messageBuffer = []
+            this.state.timeOfLastPendingRelay = false
+          } else {
+            // add the time interval between two tx
+            this.state.timeOfLastPendingRelay = Date.now()
           }
 
           this.state.timeOfLastRelayS = Date.now()
@@ -264,115 +287,124 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
           console.log('***********************************\n')
         }
 
-        this.logger.info('Checking for newly finalized transactions...')
-        if (
-          !(await this._isTransactionFinalized(
-            this.state.nextUnfinalizedTxHeight
-          ))
-        ) {
-          this.logger.info('Did not find any newly finalized transactions', {
-            retryAgainInS: Math.floor(this.options.pollingInterval / 1000),
+        // scanning the new messages only if the pending messages are relayed
+        // to l1
+        if (this.state.timeOfLastPendingRelay === false) {
+          this.logger.info('Checking for newly finalized transactions...')
+          if (
+            !(await this._isTransactionFinalized(
+              this.state.nextUnfinalizedTxHeight
+            ))
+          ) {
+            this.logger.info('Did not find any newly finalized transactions', {
+              retryAgainInS: Math.floor(this.options.pollingInterval / 1000),
+            })
+
+            continue
+          }
+
+          this.state.lastFinalizedTxHeight = this.state.nextUnfinalizedTxHeight
+          while (
+            await this._isTransactionFinalized(this.state.nextUnfinalizedTxHeight)
+          ) {
+            const size = (
+              await this._getStateBatchHeader(this.state.nextUnfinalizedTxHeight)
+            ).batch.batchSize.toNumber()
+            this.logger.info(
+              'Found a batch of finalized transaction(s), checking for more...',
+              { batchSize: size }
+            )
+            this.state.nextUnfinalizedTxHeight += size
+
+            // Only deal with ~1000 transactions at a time so we can limit the amount of stuff we
+            // need to keep in memory. We operate on full batches at a time so the actual amount
+            // depends on the size of the batches we're processing.
+            const numTransactionsToProcess =
+              this.state.nextUnfinalizedTxHeight -
+              this.state.lastFinalizedTxHeight
+
+            if (numTransactionsToProcess > 1000) {
+              break
+            }
+          }
+
+          this.logger.info('Found finalized transactions', {
+            totalNumber:
+              this.state.nextUnfinalizedTxHeight -
+              this.state.lastFinalizedTxHeight,
           })
 
-          continue
-        }
-
-        this.state.lastFinalizedTxHeight = this.state.nextUnfinalizedTxHeight
-        while (
-          await this._isTransactionFinalized(this.state.nextUnfinalizedTxHeight)
-        ) {
-          const size = (
-            await this._getStateBatchHeader(this.state.nextUnfinalizedTxHeight)
-          ).batch.batchSize.toNumber()
-          this.logger.info(
-            'Found a batch of finalized transaction(s), checking for more...',
-            { batchSize: size }
-          )
-          this.state.nextUnfinalizedTxHeight += size
-
-          // Only deal with ~1000 transactions at a time so we can limit the amount of stuff we
-          // need to keep in memory. We operate on full batches at a time so the actual amount
-          // depends on the size of the batches we're processing.
-          const numTransactionsToProcess =
-            this.state.nextUnfinalizedTxHeight -
-            this.state.lastFinalizedTxHeight
-
-          if (numTransactionsToProcess > 1000) {
-            break
-          }
-        }
-
-        this.logger.info('Found finalized transactions', {
-          totalNumber:
-            this.state.nextUnfinalizedTxHeight -
+          const messages = await this._getSentMessages(
             this.state.lastFinalizedTxHeight,
-        })
+            this.state.nextUnfinalizedTxHeight
+          )
 
-        const messages = await this._getSentMessages(
-          this.state.lastFinalizedTxHeight,
-          this.state.nextUnfinalizedTxHeight
-        )
+          for (const message of messages) {
+            this.logger.info('Found a message sent during transaction', {
+              index: message.parentTransactionIndex,
+            })
+            if (await this._wasMessageRelayed(message)) {
+              this.logger.info('Message has already been relayed, skipping.')
+              continue
+            }
 
-        for (const message of messages) {
-          this.logger.info('Found a message sent during transaction', {
-            index: message.parentTransactionIndex,
-          })
-          if (await this._wasMessageRelayed(message)) {
-            this.logger.info('Message has already been relayed, skipping.')
-            continue
+            if (!this.state.filter.includes(message.target)) {
+              this.logger.info('Message not intended for target, skipping.')
+              continue
+            }
+
+            this.logger.info(
+              'Message not yet relayed. Attempting to generate a proof...'
+            )
+            const proof = await this._getMessageProof(message)
+            this.logger.info(
+              'Successfully generated a proof. Attempting to relay to Layer 1...'
+            )
+
+            // await this._relayMessageToL1(message, proof)
+            const messageToSend = {
+              payload: {
+                target: message.target,
+                message: message.message,
+                sender: message.sender,
+                messageNonce: message.messageNonce,
+                proof,
+              },
+              message,
+            }
+            this.state.messageBuffer.push(messageToSend)
           }
 
-          if (!this.state.filter.includes(message.target)) {
-            this.logger.info('Message not intended for target, skipping.')
-            continue
+          if (messages.length === 0) {
+            this.logger.info('Did not find any L2->L1 messages', {
+              retryAgainInS: Math.floor(this.options.pollingInterval / 1000),
+            })
+          } else {
+            // Clear the event cache to avoid keeping every single event in memory and eventually
+            // getting OOM killed. Messages are already sorted in ascending order so the last message
+            // will have the highest batch index.
+            const lastMessage = messages[messages.length - 1]
+
+            // Find the batch corresponding to the last processed message.
+            const lastProcessedBatch = await this._getStateBatchHeader(
+              lastMessage.parentTransactionIndex
+            )
+
+            // Remove any events from the cache for batches that should've been processed by now.
+            this.state.eventCache = this.state.eventCache.filter((event) => {
+              return event.args._batchIndex > lastProcessedBatch.batch.batchIndex
+            })
           }
 
           this.logger.info(
-            'Message not yet relayed. Attempting to generate a proof...'
+            'Finished searching through newly finalized transactions',
+            {
+              retryAgainInS: Math.floor(this.options.pollingInterval / 1000),
+            }
           )
-          const proof = await this._getMessageProof(message)
-          this.logger.info(
-            'Successfully generated a proof. Attempting to relay to Layer 1...'
-          )
-
-          // await this._relayMessageToL1(message, proof)
-          const messageToSend = {
-            target: message.target,
-            message: message.message,
-            sender: message.sender,
-            messageNonce: message.messageNonce,
-            proof,
-          }
-          this.state.messageBuffer.push(messageToSend)
-        }
-
-        if (messages.length === 0) {
-          this.logger.info('Did not find any L2->L1 messages', {
-            retryAgainInS: Math.floor(this.options.pollingInterval / 1000),
-          })
         } else {
-          // Clear the event cache to avoid keeping every single event in memory and eventually
-          // getting OOM killed. Messages are already sorted in ascending order so the last message
-          // will have the highest batch index.
-          const lastMessage = messages[messages.length - 1]
-
-          // Find the batch corresponding to the last processed message.
-          const lastProcessedBatch = await this._getStateBatchHeader(
-            lastMessage.parentTransactionIndex
-          )
-
-          // Remove any events from the cache for batches that should've been processed by now.
-          this.state.eventCache = this.state.eventCache.filter((event) => {
-            return event.args._batchIndex > lastProcessedBatch.batch.batchIndex
-          })
+          this.logger.info('Waiting for the pending tx to be finailized')
         }
-
-        this.logger.info(
-          'Finished searching through newly finalized transactions',
-          {
-            retryAgainInS: Math.floor(this.options.pollingInterval / 1000),
-          }
-        )
       } catch (err) {
         this.logger.error('Caught an unhandled error', {
           message: err.toString(),
@@ -648,10 +680,11 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
         proof,
         { gasPrice }
       )
-      return this.options.l1Wallet.provider.waitForTransaction(
+      const tx = await this.options.l1Wallet.provider.waitForTransaction(
         txResponse.hash,
         this.options.numConfirmations
       )
+      return tx
     }
 
     const minGasPrice = await this._getGasPriceInGwei(this.options.l1Wallet)
@@ -687,10 +720,11 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
       const txResponse = await this.state.OVM_L1MultiMessageRelayerFast.connect(
         this.options.l1Wallet
       ).batchRelayMessages(messages, { gasPrice })
-      return this.options.l1Wallet.provider.waitForTransaction(
+      const tx = await this.options.l1Wallet.provider.waitForTransaction(
         txResponse.hash,
         this.options.numConfirmations
       )
+      return tx
     }
 
     const minGasPrice = await this._getGasPriceInGwei(this.options.l1Wallet)

--- a/packages/omgx/message-relayer-fast/src/types.ts
+++ b/packages/omgx/message-relayer-fast/src/types.ts
@@ -32,10 +32,15 @@ export interface StateRootProof {
   siblings: string[]
 }
 
-export interface BatchMessage {
+interface BatchMessagePayload {
   target: string
   message: string
   sender: string
   messageNonce: number
   proof: SentMessageProof
+}
+
+export interface BatchMessage {
+  payload: BatchMessagePayload
+  message: SentMessage
 }


### PR DESCRIPTION
Currently, the YNATM package is responsible for gas price logic. It starts with a low value, and gradually increments the gas price until the messages get through. Unfortunately, this can go wrong, resulting in stuck transactions that do not get relayed promptly. 

In this scenario, the gas price (1) increases to above `maximum_value`, and (2) stays above that value for longer than `timeout`, resulting in a reject error, which we presently don't handle automatically, but rather, manually. 

The goal of these changes is to automatically deal with the rejected messages, by keeping track of them in a buffer, and relaying them until the buffer is empty.